### PR TITLE
Dirty hack to print alpha_z (only for plotting) in LET model implemen…

### DIFF
--- a/src/Calculus.cpp
+++ b/src/Calculus.cpp
@@ -959,7 +959,10 @@ void Calculus::rapidLEM_Russo2011(double &alphaIon,
                     log(survivalSingleImpact) * (density * area_nucleus) / (CONV * let);
         alpha_D = alpha_X * (1 - (density * area_nucleus * doseSingleImpact) / (CONV * let)) +
                     (1 - survivalSingleImpact) * (density * area_nucleus) / (CONV * let);
-        
+
+        cout << setprecision(6) << endl << "plot_E_alphaz_RBE," << tracks[k].getKineticEnergy() << "," << alpha_z << "," << alpha_z / alpha_X << endl << endl;
+
+
         if( D_t == 0 )
             beta_z = 0;
         else
@@ -973,6 +976,8 @@ void Calculus::rapidLEM_Russo2011(double &alphaIon,
         alpha_tot += weight * let * alpha_D;
         sqrt_beta_tot += weight * let * sqrt(beta_D);
         meanLet += weight * let;
+
+
     }
     
     alphaIon = alpha_tot / meanLet;
@@ -1015,6 +1020,8 @@ void Calculus::rapidLEM_Scholz2006(double &alphaIon,
         doseSingleImpact = CONV * track->getLet() / (tracks.getDensity() * M_PI * pow(nucleus.getRadius(), 2));
         
         alpha_z = -log(survivalSingleImpact) / doseSingleImpact;
+
+        cout << setprecision(6) << endl << "plot_E_alphaz_RBE," << track->getKineticEnergy() << "," << alpha_z << "," << alpha_z / alpha_X << endl << endl;
         
         if( D_t == 0 )
             beta_z = 0;


### PR DESCRIPTION
…tations.

In order to use compile the code, then run it with following command:

```
DATA=/home/grzanka/CLionProjects/Survival/data ./survival \
 -projectName test\
 -model LEMIII \
-calculusType rapidLEM_Russo2011 \
-LEM_alpha0 0.5 -LEM_beta0 0.05 -LEM_rNucleus 5.0 -LEM_Dt 14.0 \
-ion H -energies `seq 1 1 200` -output LQ_pars\
 2>&1 | grep plot_E_alphaz_RBE > data.csv
```

Plotting can be done with simple Python code (using pandas and matplotlib libraries):
```
import pandas as pd
import matplotlib
%matplotlib inline
import matplotlib.pylab as plt
df = pd.read_csv('data.csv', sep=",", names=('tmp','E','alpha_z', 'RBE'))
fig, ax = plt.subplots(1,1)
ax.set_ylim(0.8, 1.6)
ax.axhline(1.0, color='k')
ax.axhline(1.1, color='k')
ax.axvline(70, color='pink')
df.plot('E', 'RBE', ax=ax, style='.', label="Survival calc", color='red');
```

![image](https://user-images.githubusercontent.com/7374733/73557709-fb74d880-4451-11ea-91cf-dca55946d692.png)

